### PR TITLE
Using stdlib::ensure_resource() to guarantee package definition only …

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,8 +11,7 @@
 #
 class apparmor::install inherits apparmor{
 
-  package { $package_names:
+  ensure_resource('package', $package_names, {
     ensure => $package_ensure,
-  }
-
+    })
 }


### PR DESCRIPTION
…once

In some cases when you have multiple apparmor rules definitions we could get
duplicate declaration error for apparmor package because of include within
rule definition.

This fix prevents this behaviour(but adds stdlib dependency).

Signed-off-by: Igor Shishkin me@teran.ru
